### PR TITLE
#7 [FEAT] Token Refresh 할 때 client_secret 전달하도록 추가

### DIFF
--- a/pkg/keycloak/client.go
+++ b/pkg/keycloak/client.go
@@ -93,6 +93,7 @@ func (k *keycloakClient) RefreshAccessToken(refreshToken string) (*KeycloakAcces
 	form.Set("grant_type", "refresh_token")
 	form.Set("client_id", k.config.ClientID)
 	form.Set("refresh_token", refreshToken)
+	form.Set("client_secret", k.config.ClientSecret)
 
 	req, err := http.NewRequest("POST", tokenUrl, bytes.NewBufferString(form.Encode()))
 	if err != nil {


### PR DESCRIPTION
- Token Refresh 할 때 client_secret 전달하도록 추가

confidential client 전환에 따라 refresh 할 때도 client_secret이 필요해짐. 이에 따라 전달하도록 추가