### PR TITLE
#11 [FEAT] 더미 Backchannel Logout 핸들러 추가

### DIFF
--- a/internal/handlers/keycloak_handlers.go
+++ b/internal/handlers/keycloak_handlers.go
@@ -17,6 +17,7 @@ type KeycloakHandlers interface {
 	RefreshToken(c *gin.Context)
 	Logout(c *gin.Context)
 	Login(c *gin.Context)
+	DummyBackchannelLogout(c *gin.Context)
 }
 
 type keycloakHandlers struct {
@@ -255,4 +256,9 @@ func (k *keycloakHandlers) Login(c *gin.Context) {
 	}
 
 	c.Redirect(http.StatusFound, loginUrl)
+}
+
+func (k *keycloakHandlers) DummyBackchannelLogout(c *gin.Context) {
+
+	c.Status(http.StatusOK)
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -56,6 +56,7 @@ func (r *router) setupRoutes() {
 	r.engine.POST("/keycloak/refresh", r.keycloakHandler.RefreshToken)
 	r.engine.DELETE("/keycloak/logout", r.keycloakHandler.Logout)
 	r.engine.GET("/keycloak/login", r.keycloakHandler.Login)
+	r.engine.POST("/keycloak/backchannel-logout", r.keycloakHandler.DummyBackchannelLogout)
 
 	// 404 핸들러
 	r.engine.NoRoute(r.errorHandlers.NotFound)


### PR DESCRIPTION
- 더미 Backchannel Logout 핸들러 추가

 로그아웃 전파시에 등록된 핸들러가 없어 오류 로그가 발생중임. 이에 더미 헨들러를 추가하여 로그를 보이지 않게 함.
  POST /keycloak/backchannel-logout 더미 Backchannel Logout 핸들러 추가